### PR TITLE
Thread-safe message sending and reader loop error dispatch

### DIFF
--- a/src/main/java/io/moderne/jsonrpc/JsonRpc.java
+++ b/src/main/java/io/moderne/jsonrpc/JsonRpc.java
@@ -92,7 +92,13 @@ public class JsonRpc {
                             requestId = request.getId();
                             JsonRpcMethod<?> method = methods.get(request.getMethod());
                             if (method == null) {
-                                messageHandler.send(JsonRpcError.methodNotFound(request.getId(), request.getMethod()), formatter);
+                                // Fork error sends off the reader thread to avoid
+                                // deadlock with synchronized send()
+                                Object errorId = request.getId();
+                                String errorMethod = request.getMethod();
+                                ForkJoinTask.adapt(() ->
+                                        messageHandler.send(JsonRpcError.methodNotFound(errorId, errorMethod), formatter)
+                                ).fork();
                             } else {
                                 ForkJoinTask.adapt(() -> {
                                     try {
@@ -109,7 +115,13 @@ public class JsonRpc {
                             }
                         }
                     } catch (Throwable t) {
-                        messageHandler.send(JsonRpcError.internalError(requestId, t), formatter);
+                        // Fork error sends off the reader thread to avoid
+                        // deadlock with synchronized send()
+                        Object errorReqId = requestId;
+                        Throwable errorT = t;
+                        ForkJoinTask.adapt(() ->
+                                messageHandler.send(JsonRpcError.internalError(errorReqId, errorT), formatter)
+                        ).fork();
                     }
                 }
             }

--- a/src/main/java/io/moderne/jsonrpc/handler/HeaderDelimitedMessageHandler.java
+++ b/src/main/java/io/moderne/jsonrpc/handler/HeaderDelimitedMessageHandler.java
@@ -161,14 +161,18 @@ public class HeaderDelimitedMessageHandler implements MessageHandler {
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             effectiveFormatter.serialize(msg, bos);
             byte[] content = bos.toByteArray();
-            outputStream.write(("Content-Length: " + content.length + "\r\n").getBytes());
-            if (effectiveFormatter.getEncoding() != StandardCharsets.UTF_8) {
-                outputStream.write(("Content-Type: application/vscode-jsonrpc;charset=" + effectiveFormatter.getEncoding().name() + "\r\n").getBytes());
+            // Synchronize writes so concurrent sends (e.g. from callback handlers
+            // and the main thread) don't interleave headers and content.
+            synchronized (outputStream) {
+                outputStream.write(("Content-Length: " + content.length + "\r\n").getBytes());
+                if (effectiveFormatter.getEncoding() != StandardCharsets.UTF_8) {
+                    outputStream.write(("Content-Type: application/vscode-jsonrpc;charset=" + effectiveFormatter.getEncoding().name() + "\r\n").getBytes());
+                }
+                outputStream.write('\r');
+                outputStream.write('\n');
+                outputStream.write(content);
+                outputStream.flush();
             }
-            outputStream.write('\r');
-            outputStream.write('\n');
-            outputStream.write(content);
-            outputStream.flush();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/src/main/java/io/moderne/jsonrpc/handler/NewLineDelimitedMessageHandler.java
+++ b/src/main/java/io/moderne/jsonrpc/handler/NewLineDelimitedMessageHandler.java
@@ -50,9 +50,11 @@ public class NewLineDelimitedMessageHandler implements MessageHandler {
     @Override
     public void send(JsonRpcMessage msg, MessageFormatter formatter) {
         try {
-            formatter.serialize(msg, outputStream);
-            outputStream.write(new byte[]{'\n'});
-            outputStream.flush();
+            synchronized (outputStream) {
+                formatter.serialize(msg, outputStream);
+                outputStream.write(new byte[]{'\n'});
+                outputStream.flush();
+            }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
## Summary

- **Synchronize `send()` on the output stream** in both `HeaderDelimitedMessageHandler` and `NewLineDelimitedMessageHandler`. Without this, concurrent sends (from callback handlers + main thread) interleave headers and content bytes, corrupting the wire protocol.
- **Move error sends in the reader loop to forked tasks.** The reader thread must never block on `synchronized(outputStream)` — if a callback handler holds the send lock while waiting for a response, the reader can't deliver that response, creating a deadlock.

These fixes are necessary when the RPC peer allows concurrent request handling (e.g. C#'s StreamJsonRpc with `SynchronizationContext = null`), which causes multiple Java threads to send responses/requests simultaneously.

## Test plan

- [x] Single-repo C# recipe runs complete successfully
- [ ] CI tests pass