### PR TITLE
Fix shutdown race condition

### DIFF
--- a/src/main/java/io/moderne/jsonrpc/JsonRpc.java
+++ b/src/main/java/io/moderne/jsonrpc/JsonRpc.java
@@ -56,6 +56,16 @@ public class JsonRpc {
     public CompletableFuture<JsonRpcSuccess> send(JsonRpcRequest request) {
         CompletableFuture<JsonRpcSuccess> response = new CompletableFuture<>();
         openRequests.put(request.getId(), response);
+        if (shutdown) {
+            // Reader loop already exited (peer EOF or explicit shutdown) and
+            // may have drained openRequests before our put. Fail the future
+            // ourselves; completeExceptionally is a no-op if the reader did
+            // observe our entry and failed it first.
+            openRequests.remove(request.getId());
+            response.completeExceptionally(new JsonRpcException(
+                    JsonRpcError.internalError(null, "JSON-RPC peer closed the stream")));
+            return response;
+        }
         messageHandler.send(request, formatter);
         return response;
     }
@@ -113,15 +123,16 @@ public class JsonRpc {
                         }
                     } catch (EOFException e) {
                         // Peer closed the stream — there's nothing more to read.
-                        // Fail any in-flight requests once and exit the loop
-                        // instead of spinning on the closed pipe.
+                        // Set shutdown FIRST so a concurrent send() observes it
+                        // and fails its own future after put; otherwise a request
+                        // registered after this drain would be stranded.
+                        shutdown = true;
                         JsonRpcException eof = new JsonRpcException(
                                 JsonRpcError.internalError(null, "JSON-RPC peer closed the stream"));
                         for (CompletableFuture<JsonRpcSuccess> future : openRequests.values()) {
                             future.completeExceptionally(eof);
                         }
                         openRequests.clear();
-                        shutdown = true;
                     } catch (JsonRpcReceiveException e) {
                         // Frame- or parse-level failure on an inbound message.
                         // Send the error back to the peer; do NOT touch


### PR DESCRIPTION
**What**:
A follow-up to #16.
Fix a race in `JsonRpc.send()`/EOF handler where a request registered after the reader loop drained openRequests on peer EOF would hang until the caller’s timeout instead of failing with `JsonRpcException`.

**Why**:
Fix broken CI:
```
JsonRpcTest > readerLoopExitsCleanlyOnEof() FAILED
    java.lang.AssertionError: 
    Expecting a throwable with cause being an instance of:
      io.moderne.jsonrpc.JsonRpcException
    but current throwable has no cause.
    Throwable that failed the check:
    java.util.concurrent.TimeoutException
```