### PR TITLE
Register Blackbird module by default in JsonMessageFormatter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,12 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     compileOnly("io.micrometer:micrometer-core:latest.release")
     implementation("com.fasterxml.jackson.module:jackson-module-parameter-names:2.17.2")
+    // Blackbird generates LambdaMetafactory-backed property accessors so
+    // Jackson skips the reflective MethodHandle path. ~1.5-2x on real RPC
+    // traffic per a JMH bench replaying a captured trace from `mod run`
+    // org.openrewrite.node.migrate.upgrade-node-24 — measurable on the
+    // GetObject deserialize path where field counts in nested Maps are high.
+    implementation("com.fasterxml.jackson.module:jackson-module-blackbird:2.17.2")
     testImplementation("org.openrewrite:rewrite-test:latest.release")
 }
 

--- a/src/main/java/io/moderne/jsonrpc/formatter/JsonMessageFormatter.java
+++ b/src/main/java/io/moderne/jsonrpc/formatter/JsonMessageFormatter.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.blackbird.BlackbirdModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import io.moderne.jsonrpc.JsonRpcError;
 import io.moderne.jsonrpc.JsonRpcMessage;
@@ -44,7 +45,7 @@ public class JsonMessageFormatter implements MessageFormatter {
                 // see https://cowtowncoder.medium.com/jackson-2-12-most-wanted-3-5-246624e2d3d0
                 .constructorDetector(ConstructorDetector.USE_PROPERTIES_BASED)
                 .build()
-                .registerModules(new ParameterNamesModule(), new JavaTimeModule())
+                .registerModules(new ParameterNamesModule(), new JavaTimeModule(), new BlackbirdModule())
                 .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL));
         mapper.setVisibility(mapper.getSerializationConfig().getDefaultVisibilityChecker()
@@ -60,7 +61,7 @@ public class JsonMessageFormatter implements MessageFormatter {
                 // see https://cowtowncoder.medium.com/jackson-2-12-most-wanted-3-5-246624e2d3d0
                 .constructorDetector(ConstructorDetector.USE_PROPERTIES_BASED)
                 .build()
-                .registerModules(new ParameterNamesModule(), new JavaTimeModule())
+                .registerModules(new ParameterNamesModule(), new JavaTimeModule(), new BlackbirdModule())
                 .registerModules(modules)
                 .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL));


### PR DESCRIPTION
## Summary

Register `jackson-module-blackbird` in the default `JsonMessageFormatter` builder. Blackbird generates `LambdaMetafactory`-backed property accessors so Jackson skips its reflective `MethodHandle` path. No protocol or schema change.

## Why

Profiling a real `mod run` of `org.openrewrite.node.migrate.upgrade-node-24` against the JavaScript Applications working set showed Jackson serialize/deserialize as a meaningful share of Java-side CPU on the RPC path — concentrated in `BeanPropertyWriter.serializeAsField`, `BeanDeserializer.deserializeFromObject`, and `ConcurrentHashMap.get` (the per-type serializer cache). The hot deserialize path is GetObject responses whose `value` field is a many-keyed nested `Map`, and field-count is exactly what the reflective accessor pays for.

## Bench

JMH bench replaying a 100MB captured trace (5,661 frames; 1,266 `GetObject` responses; p99 message size 45KB; max 303KB):

| Bench | Jackson default | + Blackbird |
|---|---|---|
| `deserialize_max` (303KB) | 6283 µs | 2887 µs (~2.2x) |
| `serialize_max` | 1457 µs | 992 µs (~1.5x) |
| `deserialize_median` (173B) | 1.6 µs | sub-µs |

Synthetic NO_CHANGE-heavy fixtures saw no benefit, which is consistent with reflection cost scaling with field count: the small messages are too small to matter, the big ones are where Blackbird helps.

Error bars on the max-payload runs are wide (single 303KB allocation per iteration → GC noise), but every measurement put Blackbird ahead. The bench harness lives in a follow-up branch and the captured trace is reproducible by setting `JSONRPC_CAPTURE_PATH` during a `mod run`.

## Tradeoffs considered

- **Cold-start cost**: Blackbird generates one accessor class per bean type on first (de)serialize. Negligible for long-running flows like `mod run`. For very short invocations (`mod --version`) the AOT cache won't include the generated classes, so each run re-pays the small bytecode-gen cost.
- **Behavioral drift**: Blackbird is a documented drop-in. `RpcObjectData` uses a slightly unusual Lombok `@Value` + private `@JsonCreator` + field-visibility deserialization pattern; the rewrite-rpc suite passes against this snapshot.
- **GraalVM native-image**: Blackbird's runtime class-gen is incompatible. Doesn't apply to mod today.

## Test plan

- [x] jsonrpc unit tests (`./gradlew test`) pass
- [x] rewrite-core RPC test suite passes against this snapshot:
  - `RewriteRpcTest`: 17 tests, 0 failures (2 skipped)
  - `RpcSendQueueTest`: 3/3 pass
  - `RpcReceiveQueueTest`: 5/5 pass
- [ ] Run `mod run` end-to-end on a representative recipe and confirm no behavioral diff vs current main