### PR TITLE
Revert Blackbird default; align Jackson to 2.21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,13 +15,7 @@ dependencies {
 
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     compileOnly("io.micrometer:micrometer-core:latest.release")
-    implementation("com.fasterxml.jackson.module:jackson-module-parameter-names:2.17.2")
-    // Blackbird generates LambdaMetafactory-backed property accessors so
-    // Jackson skips the reflective MethodHandle path. ~1.5-2x on real RPC
-    // traffic per a JMH bench replaying a captured trace from `mod run`
-    // org.openrewrite.node.migrate.upgrade-node-24 — measurable on the
-    // GetObject deserialize path where field counts in nested Maps are high.
-    implementation("com.fasterxml.jackson.module:jackson-module-blackbird:2.17.2")
+    implementation("com.fasterxml.jackson.module:jackson-module-parameter-names:2.21.1")
     testImplementation("org.openrewrite:rewrite-test:latest.release")
 }
 

--- a/src/main/java/io/moderne/jsonrpc/formatter/JsonMessageFormatter.java
+++ b/src/main/java/io/moderne/jsonrpc/formatter/JsonMessageFormatter.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.util.TokenBuffer;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.blackbird.BlackbirdModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import io.moderne.jsonrpc.JsonRpcError;
 import io.moderne.jsonrpc.JsonRpcMessage;
@@ -48,7 +47,7 @@ public class JsonMessageFormatter implements MessageFormatter {
                 // see https://cowtowncoder.medium.com/jackson-2-12-most-wanted-3-5-246624e2d3d0
                 .constructorDetector(ConstructorDetector.USE_PROPERTIES_BASED)
                 .build()
-                .registerModules(new ParameterNamesModule(), new JavaTimeModule(), new BlackbirdModule())
+                .registerModules(new ParameterNamesModule(), new JavaTimeModule())
                 .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL));
         mapper.setVisibility(mapper.getSerializationConfig().getDefaultVisibilityChecker()
@@ -62,7 +61,7 @@ public class JsonMessageFormatter implements MessageFormatter {
         this(JsonMapper.builder()
                 .constructorDetector(ConstructorDetector.USE_PROPERTIES_BASED)
                 .build()
-                .registerModules(new ParameterNamesModule(), new JavaTimeModule(), new BlackbirdModule())
+                .registerModules(new ParameterNamesModule(), new JavaTimeModule())
                 .registerModules(modules)
                 .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL));


### PR DESCRIPTION
## Summary

- Revert the `BlackbirdModule` default registration shipped in #20 (jsonrpc 1.0.8).
- Bump `jackson-module-parameter-names` from 2.17.2 to 2.21.1 to align with the Jackson version consumers (moderne-cli, recent openrewrite/rewrite) force via their build conventions.

## Why revert Blackbird

The original PR's bench was on Jackson 2.17.2 — `RealTraceBench` (replaying a captured `mod run` trace) showed Blackbird at ~2x faster deserialize and ~1.5x serialize. Re-running the same bench against Jackson 2.21.x tells a different story:

| Bench (Jackson 2.21.1, real trace, max=303KB payload) | Vanilla | Blackbird |
|---|---|---|
| `serialize_max` | **317 ± 19 µs** | **540 ± 31 µs** ← ~70% slower |
| `deserialize_max` | 1537 ± 220 µs | 1500 ± 68 µs (a wash) |

The serialize regression is real (tight error bars, no CI overlap). End-to-end on `mod run org.openrewrite.node.migrate.upgrade-node-24` against the JS Applications working set, BatchVisit p50/p99 went up 4-12x / 4-65x against the pre-Blackbird baseline.

We don't yet have a clean answer for *why* Blackbird 2.21.x regresses serialize while 2.17.2 didn't — Jackson 2.21 likely shifted the reflective-vs-generated-accessor balance — but the data is unambiguous: shipping Blackbird as a default in this Jackson lineage is a net loss for the primary consumer.

## Why bump parameter-names

`moderne-cli` and recent `openrewrite/rewrite` force all `com.fasterxml.jackson*` to 2.21.1 via dependency resolution rules. Pinning `jackson-module-parameter-names` to 2.17.2 in jsonrpc resolves to the forced 2.21.1 anyway in those consumers, but locally and in any consumer that doesn't force, the 2.17.2 / 2.21.1 mix is the slightly-skewed combo that may explain some of the Blackbird-regression weirdness above. Aligning the pin to 2.21.1 keeps BOM resolution stable.

## What stays

- The streaming `TokenBuffer`-based deserialize introduced in #18 stays — that was the deserialize-side win Blackbird was attempting to chase, already shipped.

## Test plan

- [x] jsonrpc unit tests pass (`./gradlew test`)
- [ ] Re-run `mod run upgrade-node-24` against the JS Applications working set with this version and confirm BatchVisit p50/p99 return to the pre-1.0.8 baseline