### PR TITLE
Always serialize JSON-RPC error-response id (null when uncorrelated)

### DIFF
--- a/src/main/java/io/moderne/jsonrpc/JsonRpcError.java
+++ b/src/main/java/io/moderne/jsonrpc/JsonRpcError.java
@@ -15,6 +15,7 @@
  */
 package io.moderne.jsonrpc;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
@@ -26,6 +27,12 @@ import java.io.StringWriter;
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class JsonRpcError extends JsonRpcResponse {
+    // JSON-RPC 2.0 requires error responses to carry an "id" (null when the error
+    // can't be correlated to a request, e.g. an internal error on a background
+    // thread). Without ALWAYS, a global NON_NULL inclusion omits a null id, and
+    // strict peers (e.g. StreamJsonRpc on the .NET side) reject the frame with
+    // "id property missing" and abort — masking the real error.
+    @JsonInclude(JsonInclude.Include.ALWAYS)
     @JsonDeserialize(using = JsonRpcIdDeserializer.class)
     Object id;
 


### PR DESCRIPTION
**Draft / checkpoint.** JSON-RPC 2.0 requires a Response to carry an `id` (null when the error can't be correlated to a request, e.g. an internal error on a background thread). A global `NON_NULL` inclusion dropped a null id, so strict peers (StreamJsonRpc on the .NET side) rejected the frame with "id property missing" and aborted (exit 134) — masking the real error (a Java-side OOM surfaced only as a confusing C# RPC crash). Force `JsonRpcError.id` to always serialize. Found while profiling .NET migration recipe runs via the Moderne CLI.